### PR TITLE
Fix full_name setting for operator

### DIFF
--- a/app/api/composer/history_convert_utils.py
+++ b/app/api/composer/history_convert_utils.py
@@ -233,7 +233,7 @@ def _init_operator_dict(ind, operator, o_id, gen_id):
     operator_node['operator_id'] = o_id
     operator_node['type'] = 'evo_operator'
     operator_node['name'] = operator.type_
-    operator_node['full_name'] = ', '.join(operator.operators)
+    operator_node['full_name'] = ', '.join(map(str, operator.operators))
 
     # temporary fields
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # FEDOT
-fedot==0.7.0
+fedot==0.7.1
 
 # Unique requirements
 flask-socketio==5.3.2


### PR DESCRIPTION
Fix setting of operator full name to work in case of not fully deserialized operators. 
Issue: https://github.com/aimclub/GOLEM/issues/109 